### PR TITLE
update endpoint to use content feed

### DIFF
--- a/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
+++ b/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		8AA6BA352AC491E000B93B6C /* secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 8AA6BA342AC491E000B93B6C /* secrets.xcconfig */; };
 		8AA6BA372AC496C800B93B6C /* DesignKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8AA6BA362AC496C800B93B6C /* DesignKit */; };
 		AA7BDC602AB2571800ACCACF /* MoSoContentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */; };
 		AA7BDC642AB2571900ACCACF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA7BDC632AB2571900ACCACF /* Assets.xcassets */; };
@@ -41,7 +40,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		8AA6BA342AC491E000B93B6C /* secrets.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = secrets.xcconfig; path = ../../../../MoSoContent/MoSoContent/Config/secrets.xcconfig; sourceTree = "<group>"; };
 		AA7BDC5C2AB2571800ACCACF /* MoSoContent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MoSoContent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoSoContentApp.swift; sourceTree = "<group>"; };
 		AA7BDC632AB2571900ACCACF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -53,7 +51,6 @@
 		AA7BDC7C2AB2571900ACCACF /* MoSoContentUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoSoContentUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		AA7BDC892AB2578100ACCACF /* MoSoContentKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MoSoContentKit; path = ../..; sourceTree = "<group>"; };
 		AA7BDC8D2AB25C2200ACCACF /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		AA7BDC982AB2C3B700ACCACF /* secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets.xcconfig; sourceTree = "<group>"; };
 		AA7BDC992AB2C54200ACCACF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AAE52B692AB4CFE300956FBE /* AppConfigurator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfigurator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -117,7 +114,6 @@
 				AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */,
 				AA7BDC8D2AB25C2200ACCACF /* RootView.swift */,
 				AAE52B692AB4CFE300956FBE /* AppConfigurator.swift */,
-				AA7BDC972AB2C38C00ACCACF /* Config */,
 				AA7BDC962AB2C33600ACCACF /* Resources */,
 				AA7BDC652AB2571900ACCACF /* Preview Content */,
 			);
@@ -162,15 +158,6 @@
 				AA7BDC632AB2571900ACCACF /* Assets.xcassets */,
 			);
 			path = Resources;
-			sourceTree = "<group>";
-		};
-		AA7BDC972AB2C38C00ACCACF /* Config */ = {
-			isa = PBXGroup;
-			children = (
-				8AA6BA342AC491E000B93B6C /* secrets.xcconfig */,
-				AA7BDC982AB2C3B700ACCACF /* secrets.xcconfig */,
-			);
-			path = Config;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -285,7 +272,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8AA6BA352AC491E000B93B6C /* secrets.xcconfig in Resources */,
 				AA7BDC672AB2571900ACCACF /* Preview Assets.xcassets in Resources */,
 				AA7BDC642AB2571900ACCACF /* Assets.xcassets in Resources */,
 			);
@@ -376,7 +362,6 @@
 /* Begin XCBuildConfiguration section */
 		AA7BDC7E2AB2571900ACCACF /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8AA6BA342AC491E000B93B6C /* secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Demo/MozillaSocial-iOS/MoSoContent/Config/exampleSecrets.xcconfig
+++ b/Demo/MozillaSocial-iOS/MoSoContent/Config/exampleSecrets.xcconfig
@@ -1,5 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-DISCOVER_API_CONSUMER_KEY=[YOUR-CONSUMER-KEY]

--- a/Sources/MoSoClient/Endpoint.swift
+++ b/Sources/MoSoClient/Endpoint.swift
@@ -19,7 +19,7 @@ struct RecommendationsEndpoint: Endpoint {
             actualCount = recommendationCount
         }
         self.queryItems = [
-            URLQueryItem(name: Constants.locale, value: Locale.current.language.minimalIdentifier),
+            URLQueryItem(name: Constants.locale, value: Locale.current.identifier(.bcp47)),
             URLQueryItem(name: Constants.count, value: "\(actualCount)")
         ]
     }

--- a/Sources/MoSoClient/Endpoint.swift
+++ b/Sources/MoSoClient/Endpoint.swift
@@ -14,17 +14,12 @@ struct RecommendationsEndpoint: Endpoint {
     private let queryItems: [URLQueryItem]
 
     init(recommendationCount: Int? = nil) throws {
-        guard let info = Bundle.main.infoDictionary, let key = info[Constants.consumerKeyKey] as? String else {
-            throw MoSoClientError.consumerKeyNotFound
-        }
         var actualCount = Constants.defaultRecommendationsCount
         if let recommendationCount, recommendationCount >= 0, recommendationCount <= Constants.defaultRecommendationsCount {
             actualCount = recommendationCount
         }
         self.queryItems = [
-            URLQueryItem(name: Constants.consumerKey, value: key),
             URLQueryItem(name: Constants.locale, value: Locale.current.language.minimalIdentifier),
-            URLQueryItem(name: Constants.region, value: Locale.current.region?.identifier),
             URLQueryItem(name: Constants.count, value: "\(actualCount)")
         ]
     }
@@ -43,16 +38,12 @@ struct RecommendationsEndpoint: Endpoint {
     }
 
     enum Constants {
-        static let defaultRecommendationsCount = 30
-        static let host = "firefox-api-proxy.cdn.mozilla.net"
+        static let defaultRecommendationsCount = 24
+        static let host = "mozilla.social"
         static let scheme = "https"
-        // key to retrieve the actual consumer key
-        static let consumerKeyKey = "DiscoverApiConsumerKey"
-        static let path = "/desktop/v1/recommendations"
+        static let path = "/content-feed/moso/v1/discover"
         // query items keys
         static let locale = "locale"
-        static let region = "region"
         static let count = "count"
-        static let consumerKey = "consumer_key"
     }
 }


### PR DESCRIPTION
## Summary
Replace firefox new tab API with content feed API

## Implementation Details
Update endpoint to use https://mozilla.social/content-feed/moso/v1/discover?locale=en-US

## Test Steps
Run app and view that recommendations match the response from the new endpoint

## PR Checklist:
- N / A Added Unit / UI tests - consider adding tests in a separate PR
- [x] Self Review (review, clean up, documentation, run tests)
- [ ] Self Accessibility Review - accessibility will be handled in another ticket
- [x] Basic Self QA

## Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2023-10-02 at 16 15 55](https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/ee20faf4-6201-429c-9a39-9f114a23bb53)
