### PR TITLE
Fixes thumbnails not showing up after api update

### DIFF
--- a/Sources/MoSoClient/Endpoint.swift
+++ b/Sources/MoSoClient/Endpoint.swift
@@ -20,7 +20,8 @@ struct RecommendationsEndpoint: Endpoint {
         }
         self.queryItems = [
             URLQueryItem(name: Constants.locale, value: Locale.current.identifier(.bcp47)),
-            URLQueryItem(name: Constants.count, value: "\(actualCount)")
+            URLQueryItem(name: Constants.count, value: "\(actualCount)"),
+            URLQueryItem(name: Constants.imageSizes, value: Constants.requestedSizes)
         ]
     }
 
@@ -44,6 +45,10 @@ struct RecommendationsEndpoint: Endpoint {
         static let path = "/content-feed/moso/v1/discover"
         // query items keys
         static let locale = "locale"
+        static let imageSizes = "image_sizes"
+        // TODO: in this simple implementation, we are requesting one size (the smallest) for all images, used as thumbnails
+        // The request can accept multiple sizes and return multiple urls
+        static let requestedSizes = "202x"
         static let count = "count"
     }
 }

--- a/Sources/MoSoClient/RemoteRecommendation.swift
+++ b/Sources/MoSoClient/RemoteRecommendation.swift
@@ -33,7 +33,6 @@ public struct RemoteRecommendation: Decodable {
         self.excerpt = try container.decode(String.self, forKey: .excerpt)
         self.publisher = try container.decode(String.self, forKey: .publisher)
         let imagesContainer = try container.nestedContainer(keyedBy: ImageCodingKeys.self, forKey: .image)
-        print(imagesContainer.allKeys)
         let images = try imagesContainer.decode([RecommendationImage].self, forKey: .sizes)
         // TODO: in this simple implementation, we just extract the first url (if any). we will need to change it if/when we need to use more than one size.
         self.imageUrl = images.first?.url

--- a/Sources/MoSoClient/RemoteRecommendation.swift
+++ b/Sources/MoSoClient/RemoteRecommendation.swift
@@ -19,7 +19,11 @@ public struct RemoteRecommendation: Decodable {
         case title
         case excerpt
         case publisher
-        case imageUrl
+        case image
+    }
+
+    enum ImageCodingKeys: String, CodingKey {
+        case sizes
     }
 
     public init(from decoder: Decoder) throws {
@@ -28,12 +32,16 @@ public struct RemoteRecommendation: Decodable {
         self.title = try container.decode(String.self, forKey: .title)
         self.excerpt = try container.decode(String.self, forKey: .excerpt)
         self.publisher = try container.decode(String.self, forKey: .publisher)
-        self.imageUrl = try container.decodeIfPresent(String.self, forKey: .imageUrl)
+        let imagesContainer = try container.nestedContainer(keyedBy: ImageCodingKeys.self, forKey: .image)
+        print(imagesContainer.allKeys)
+        let images = try imagesContainer.decode([RecommendationImage].self, forKey: .sizes)
+        // TODO: in this simple implementation, we just extract the first url (if any). we will need to change it if/when we need to use more than one size.
+        self.imageUrl = images.first?.url
     }
 }
 
 struct RemoteRecommendations: Decodable {
-    public let recommendations: [RemoteRecommendation]
+    let recommendations: [RemoteRecommendation]
 
     enum CodingKeys: String, CodingKey {
         case data
@@ -42,5 +50,22 @@ struct RemoteRecommendations: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         recommendations = try container.decode([RemoteRecommendation].self, forKey: .data)
+    }
+}
+
+struct RecommendationImage: Decodable {
+    let url: String
+    let width: Int
+    let height: Int
+
+    enum CodingKeys: String, CodingKey {
+        case url, width, height
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.url = try container.decode(String.self, forKey: .url)
+        self.width = try container.decode(Int.self, forKey: .width)
+        self.height = try container.decode(Int.self, forKey: .height)
     }
 }


### PR DESCRIPTION
## Summary
* Fix discover api call after switching to the new api 

## Implementation Details
* Update `EndPoint`, add `image_sizes` parameter to get the images
* Update `RemoteRecommendation`, decode images container and extract url(s) from it
* Add `RecommendationImage: Decodable` type

## Test Steps
* Build, run, go to Discover and make sure the thumbnails show up

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [ ] Self Accessibility Review
- [x] Basic Self QA

## Screenshots
