### PR TITLE
Update list of recommendations (MOS-20, MOS-36)

### DIFF
--- a/Demo/MozillaSocial-iOS/.swiftlint.yml
+++ b/Demo/MozillaSocial-iOS/.swiftlint.yml
@@ -98,6 +98,7 @@ analyzer_rules: # Rules run by `swiftlint analyze`
   - unused_import
 
 included:
+  - ../../Demo
   - ../../Sources
   - ../../Tests
   - ../../MoSoContent

--- a/Sources/DesignKit/View+Extensions.swift
+++ b/Sources/DesignKit/View+Extensions.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    public func `if`<Content: View>(_ condition: Bool, modify: (Self) -> Content) -> some View {
+        if condition {
+            modify(self)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/DiscoverKit/View/RecommendationRow.swift
+++ b/Sources/DiscoverKit/View/RecommendationRow.swift
@@ -6,6 +6,15 @@ import DesignKit
 import SwiftUI
 
 struct RecommendationRow: View {
+    private enum Constants {
+        static let padding: CGFloat = 16
+        static let spacing: CGFloat = 4
+        static let lineLimit: Int = 5
+        static let imageSize: CGFloat = 24
+        static let thumbnailSize: CGFloat = 80
+        static let cornerRadius: CGFloat = 8.0
+    }
+
     let recommendation: Recommendation
     var body: some View {
         VStack {
@@ -16,19 +25,19 @@ struct RecommendationRow: View {
             }
             makeFooterView()
         }
-        .padding(.top, 16)
-        .padding(.bottom, 16)
+        .padding(.top, Constants.padding)
+        .padding(.bottom, Constants.padding)
     }
 
     func makeTextContentView() -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: Constants.spacing) {
             Text(recommendation.publisher)
                 .font(.footnote)
             Text(recommendation.title)
                 .font(.headline)
             Text(recommendation.excerpt)
                 .font(.body)
-                .lineLimit(5)
+                .lineLimit(Constants.lineLimit)
         }
     }
     // TODO: in our final implementation, we might want to use Kingfisher for images
@@ -37,8 +46,8 @@ struct RecommendationRow: View {
             if let urlString = recommendation.imageUrl, let url = URL(string: urlString) {
                 AsyncImageView(url: url)
                     .aspectRatio(contentMode: .fill)
-                    .frame(width: 80.0, height: 80.0, alignment: .center)
-                    .cornerRadius(8.0)
+                    .frame(width: Constants.thumbnailSize, height: Constants.thumbnailSize, alignment: .center)
+                    .cornerRadius(Constants.cornerRadius)
             }
             Spacer()
         }
@@ -49,12 +58,12 @@ struct RecommendationRow: View {
             Spacer()
             Image(.save)
                 .renderingMode(.template)
-                .frame(width: 24, height: 24)
-                .padding(.trailing, 16)
+                .frame(width: Constants.imageSize, height: Constants.imageSize)
+                .padding(.trailing, Constants.padding)
             ShareLink(item: recommendation.url) {
                 Image(.share)
                     .renderingMode(.template)
-                    .frame(width: 24, height: 24)
+                    .frame(width: Constants.imageSize, height: Constants.imageSize)
             }
             .buttonStyle(.plain)
         }

--- a/Sources/DiscoverKit/View/RecommendationRow.swift
+++ b/Sources/DiscoverKit/View/RecommendationRow.swift
@@ -28,6 +28,7 @@ struct RecommendationRow: View {
                 .font(.headline)
             Text(recommendation.excerpt)
                 .font(.body)
+                .lineLimit(5)
         }
     }
     // TODO: in our final implementation, we might want to use Kingfisher for images

--- a/Sources/DiscoverKit/View/RecommendationsView.swift
+++ b/Sources/DiscoverKit/View/RecommendationsView.swift
@@ -8,15 +8,25 @@ struct RecommendationsView: View {
     let recommendations: [Recommendation]
     @EnvironmentObject var viewModel: DiscoverViewModel
 
+    @Environment(\.horizontalSizeClass)
+    var sizeClass
+
+    static let maxReadableWidth: CGFloat = 700
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Color(.mosoLayerColor1).ignoresSafeArea()
-                ListView(recommendations: recommendations)
-                    .navigationDestination(for: Recommendation.self) {
-                        RecommendationDetailView(recommendation: $0)
-                            .navigationBarTitleDisplayMode(.inline)
-                    }
+                    ListView(recommendations: recommendations)
+                        .navigationDestination(for: Recommendation.self) {
+                            RecommendationDetailView(recommendation: $0)
+                                .navigationBarTitleDisplayMode(.inline)
+                                .toolbarBackground(.visible, for: .navigationBar)
+                                .toolbarBackground(Color(.mosoLayerColor1), for: .navigationBar)
+                        }
+                        .if(sizeClass == .regular) { view in
+                            view.frame(width: RecommendationsView.maxReadableWidth, alignment: .center)
+                        }
             }
         }
         .searchable(text: $viewModel.term)
@@ -41,6 +51,17 @@ struct ListView: View {
         .navigationTitle("Today's Top Picks")
         .refreshable {
             viewModel.load()
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, modify: (Self) -> Content) -> some View {
+        if condition {
+            modify(self)
+        } else {
+            self
         }
     }
 }

--- a/Sources/DiscoverKit/View/RecommendationsView.swift
+++ b/Sources/DiscoverKit/View/RecommendationsView.swift
@@ -11,6 +11,7 @@ struct RecommendationsView: View {
     @Environment(\.horizontalSizeClass)
     var sizeClass
 
+    /// Max readable width comes from our investigation we did in this PR: https://github.com/Pocket/pocket-ios/pull/763
     static let maxReadableWidth: CGFloat = 700
 
     var body: some View {
@@ -51,17 +52,6 @@ struct ListView: View {
         .navigationTitle("Today's Top Picks")
         .refreshable {
             viewModel.load()
-        }
-    }
-}
-
-extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, modify: (Self) -> Content) -> some View {
-        if condition {
-            modify(self)
-        } else {
-            self
         }
     }
 }


### PR DESCRIPTION
## Summary
Updates list of recommended items:
* Add a max readable width to the list based on our investigation we did on Pocket:  https://github.com/Pocket/pocket-ios/pull/763
* Update color for navigation header when opening article in web view
* Update line limit after discussing with Moiz
* Added folder for Demo to trigger SwiftLint rules in this directory

## Implementation Details
Minor changes, most of the code changes relates to constraining the list of recommendations to 700 for iPad layouts and created a helper function `if` 

## Test Steps
1. Run the app in various device sizes and confirm the max width for the recommendations list
2. Verify that the line limit is met in large font sizes
3. Confirm SwiftLint rules now work for code within the Demo folder

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N / A Self Accessibility Review
- [x] Basic Self QA

## Screenshots
| iPad Pro | iPhone - Dynamic Fonts |
| --- | --- |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-10-09 at 10 15 08](https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/538067f4-90f8-4f8f-aafd-1a5abff95415) | ![Simulator Screenshot - iPhone 15 Pro - 2023-10-09 at 10 31 49](https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/27ef12b9-a4aa-4a7b-b5f9-34956b998039) |