### PR TITLE
Add generic error screen

### DIFF
--- a/Sources/DiscoverKit/View/AsyncImageView.swift
+++ b/Sources/DiscoverKit/View/AsyncImageView.swift
@@ -20,8 +20,10 @@ struct AsyncImageView: View {
         AsyncContentView(source: loader) { uiImage in
             Image(uiImage: uiImage)
                 .resizable()
-        } errorContent: { _ in
-            // TODO: we might want to do something different here if the image fails to load
+        } progressContent: {
+            ProgressView()
+        }
+    errorContent: { _ in
             EmptyView()
         }
     }

--- a/Sources/DiscoverKit/View/ErrorView.swift
+++ b/Sources/DiscoverKit/View/ErrorView.swift
@@ -16,7 +16,7 @@ struct ErrorView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Sorry, Something went wrong")
                         .font(.title)
-                    Text("We are all about a healthy internet but sometimes things break.")
+                    Text("We're all about a healthy internet but sometimes things break.")
                         .font(.headline)
                     Spacer()
                 }

--- a/Sources/DiscoverKit/View/ErrorView.swift
+++ b/Sources/DiscoverKit/View/ErrorView.swift
@@ -9,12 +9,23 @@ struct ErrorView: View {
     let error: Error
 
     var body: some View {
-        // TODO: add implementation
         // TODO: add proper error logging
-        Text("There was an error \(error.localizedDescription)")
-            .refreshable {
-                viewModel.load()
+        ScrollView {
+            ZStack {
+                Color(.mosoLayerColor1).ignoresSafeArea()
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Sorry, Something went wrong")
+                        .font(.title)
+                    Text("We are all about a healthy internet but sometimes things break.")
+                        .font(.headline)
+                    Spacer()
+                }
+                .padding()
             }
+        }
+        .refreshable {
+            viewModel.load()
+        }
     }
 }
 

--- a/Sources/DiscoverKit/View/ErrorView.swift
+++ b/Sources/DiscoverKit/View/ErrorView.swift
@@ -14,7 +14,7 @@ struct ErrorView: View {
             ZStack {
                 Color(.mosoLayerColor1).ignoresSafeArea()
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Sorry, Something went wrong")
+                    Text("Sorry, something went wrong")
                         .font(.title)
                     Text("We're all about a healthy internet but sometimes things break.")
                         .font(.headline)

--- a/Sources/DiscoverKit/View/RootView.swift
+++ b/Sources/DiscoverKit/View/RootView.swift
@@ -12,7 +12,13 @@ struct RootView: View {
     var body: some View {
         AsyncContentView(source: viewModel) { recommendations in
             RecommendationsView(recommendations: recommendations)
-        } errorContent: { error in
+        } progressContent: {
+            ZStack {
+                Color(.mosoLayerColor1).ignoresSafeArea()
+                ProgressView()
+            }
+        }
+    errorContent: { error in
             ErrorView(error: error)
         }
         .background(Color(.mosoLayerColor1))

--- a/Sources/MoSoCore/AsyncLoadableView/AsyncContentView.swift
+++ b/Sources/MoSoCore/AsyncLoadableView/AsyncContentView.swift
@@ -6,16 +6,19 @@
 
 import SwiftUI
 
-public struct AsyncContentView<Source: LoadableObject, Content: View, ErrorContent: View>: View {
+public struct AsyncContentView<Source: LoadableObject, Content: View, ProgressContent: View, ErrorContent: View>: View {
     @ObservedObject var source: Source
     var content: (Source.Output) -> Content
+    var progressContent: () -> ProgressContent
     var errorContent: (Error) -> ErrorContent
 
     public init(source: Source,
                 @ViewBuilder content: @escaping (Source.Output) -> Content,
+                @ViewBuilder progressContent: @escaping () -> ProgressContent,
                 @ViewBuilder errorContent: @escaping (Error) -> ErrorContent) {
         self.source = source
         self.content = content
+        self.progressContent = progressContent
         self.errorContent = errorContent
     }
 
@@ -26,7 +29,7 @@ public struct AsyncContentView<Source: LoadableObject, Content: View, ErrorConte
                 source.load()
             }
         case .loading:
-            ProgressView()
+            progressContent()
         case .failed(let error):
             errorContent(error)
         case .ready(let output):


### PR DESCRIPTION
## Summary
* This PR adds a generic error screen to the discover tab

## Implementation Details
* Update `ErrorView` according to the provided designs

## Test Steps
* if you want to simulate an error, in `DiscoverViewModel`, after recommendations are fetched, instead of setting a `.ready(..)` state, set a `.failed(...)` and the error will show up (see animations)

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [x] Self Accessibility Review
- [x] Basic Self QA

## Screenshots
iPhone dark | iPad light
-- | --
<img src=https://github.com/MozillaSocial/mozilla-social-ios/assets/34376330/5fa2f8d1-07c9-4f3a-a338-36effedb8c9f> | <img src=https://github.com/MozillaSocial/mozilla-social-ios/assets/34376330/3c1b84cf-9bec-4a62-8e85-d8a11d7f76f5>


