### PR TITLE
feat(tests): add discover tests using quick + nimble [MOSOIOS-41]

### DIFF
--- a/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,12 +10,48 @@
       }
     },
     {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "3b123999de19bf04905bc1dfdb76f817b0f2cc00",
+        "version" : "2.1.2"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "a23ded2c91df9156628a6996ab4f347526f17b6b",
+        "version" : "2.1.2"
+      }
+    },
+    {
       "identity" : "glean-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
         "revision" : "63e6475bd275399b701951925c64fd4c9a5f7c2d",
         "version" : "54.0.0"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "d616f15123bfb36db1b1075153f73cf40605b39d",
+        "version" : "13.0.0"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "ef9aaf3f634b3a1ab6f54f1173fe2400b36e7cb8",
+        "version" : "7.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/mozilla/glean-swift", from: "54.0.0"),
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.3.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
     ],
     targets: [
         .target(
@@ -35,7 +37,12 @@ let package = Package(
         ),
         .testTarget(
             name: "DiscoverKitTests",
-            dependencies: ["DiscoverKit"]),
+            dependencies: [
+                "DiscoverKit",
+                .product(name: "Quick", package: "Quick"), 
+                    .product(name: "Nimble", package: "Nimble")
+            ]
+        ),
         .target(
             name: "ReadingListKit"),
         .testTarget(

--- a/Tests/DiscoverKitTests/DiscoverViewModelTests.swift
+++ b/Tests/DiscoverKitTests/DiscoverViewModelTests.swift
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Quick
+import Nimble
+
+@testable import DiscoverKit
+
+final class DiscoverViewModelTests: AsyncSpec {
+    override class func spec() {
+        describe("the Discover tab") {
+            var store: MockStore!
+            var tracker: MockTracker!
+            var viewModel: DiscoverViewModel!
+
+            beforeEach {
+                store = MockStore()
+                tracker = MockTracker()
+                viewModel = await DiscoverViewModel(store: store, tracker: tracker)
+                store.isThrowingError = false
+            }
+
+            describe("shows state") {
+                it("is loading during initial load") {
+                    await viewModel.load()
+                    let state = await viewModel.state
+
+                    await expect {
+                        guard case .loading = state else {
+                            return .failed(reason: "wrong enum case \(state)")
+                        }
+                        return .succeeded
+                    }.to(succeed())
+                }
+
+                it("is ready with recommendation list") {
+                    await viewModel.load()
+
+                    await expect {
+                        let state = await viewModel.state
+                        guard case .ready(let recommendations) = state else {
+                            return .failed(reason: "wrong enum case \(state) not ")
+                        }
+                        expect(recommendations.count).to(equal(1))
+                        expect(recommendations.first?.title).to(equal("test-title"))
+                        expect(recommendations.first?.excerpt).to(equal("test-excerpt"))
+                        return .succeeded
+                    }.toEventually(succeed())
+                }
+
+                it("is failed after receiving error") {
+                    store.isThrowingError = true
+                    await viewModel.load()
+
+                    await expect {
+                        let state = await viewModel.state
+                        guard case .failed = state else {
+                            return .failed(reason: "wrong enum case \(state)")
+                        }
+                        return .succeeded
+                    }.toEventually(succeed())
+                }
+            }
+
+            describe("triggers analytics") {
+                it("when recommendation is open") {
+                    await viewModel.trackRecommendationOpen(recommendationID: "id")
+                    expect(tracker.calls).to(contain("trackRecommendationOpen(recommendationID:)"))
+                }
+
+                it("when recommendation is shared") {
+                    await viewModel.trackRecommendationShare(recommendationID: "id")
+                    expect(tracker.calls).to(contain("trackRecommendationShare(recommendationID:)"))
+                }
+
+                it("when discover screen is viewed") {
+                    await viewModel.trackDiscoverScreenImpression()
+                    expect(tracker.calls).to(contain("trackDiscoverScreenImpression()"))
+                }
+
+                it("when recommendation is viewed") {
+                    await viewModel.trackRecommendationImpression(recommendationID: "id")
+                    expect(tracker.calls).to(contain("trackRecommendationImpression(recommendationID:)"))
+                }
+            }
+        }
+    }
+}

--- a/Tests/DiscoverKitTests/Mocks/MockError.swift
+++ b/Tests/DiscoverKitTests/Mocks/MockError.swift
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import XCTest
-@testable import DiscoverKit
-
-final class DiscoverKitTests: XCTestCase {
+public enum MockError: Error {
+    case fetchRecommendationsError
 }

--- a/Tests/DiscoverKitTests/Mocks/MockStore.swift
+++ b/Tests/DiscoverKitTests/Mocks/MockStore.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import MoSoAnalytics
+
+@testable import DiscoverKit
+
+/// Mock of `DiscoverTracker` used in tests
+class MockTracker: DiscoverTracker {
+    var calls: [String] = []
+
+    func trackDiscoverScreenImpression() {
+        calls.append(#function)
+    }
+
+    func trackRecommendationOpen(recommendationID: String) {
+        calls.append(#function)
+    }
+
+    func trackRecommendationShare(recommendationID: String) {
+        calls.append(#function)
+    }
+
+    func trackRecommendationBookmark(recommendationID: String) {
+        calls.append(#function)
+    }
+
+    func trackRecommendationImpression(recommendationID: String) {
+        calls.append(#function)
+    }
+}

--- a/Tests/DiscoverKitTests/Mocks/MockTracker.swift
+++ b/Tests/DiscoverKitTests/Mocks/MockTracker.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Combine
+
+@testable import DiscoverKit
+
+/// Mock of `RecommendationsStore` used in tests
+final class MockStore: RecommendationsStore {
+    var isThrowingError: Bool = false
+
+    func clearSearch() {
+    }
+
+    @Published var recommendations: [Recommendation] = []
+    public var recommendationsPublisher: Published<[Recommendation]>.Publisher { $recommendations }
+
+    func fetchRecommendations(count: Int) async throws {
+        if isThrowingError {
+            throw MockError.fetchRecommendationsError
+        }
+        recommendations = [Recommendation(recommendationID: "id", url: "test-url", title: "test-title", excerpt: "test-excerpt", publisher: "test-publisher", imageUrl: nil)]
+    }
+
+    func searchRecommendations(by term: String) {
+    }
+}


### PR DESCRIPTION
## Summary
Investigate incorporate Quick + Nimble into the project.
* Write a Pros / Cons list in comparison to XCTests
* Test framework by integrating with project and adding some Unit Tests for DiscoverKit

## Implementation Details
* Added dependencies for Quick + Nimble (used latest stable version)
* Added tests for `DiscoverViewModel` to check for state and analytics tracking calls

**Pros + Cons List** 
<img src="https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/bf0d568a-8644-444e-a9f3-7e5e6c9e80a6" width="500" height="500">

Ref: https://cyndichin.github.io/blog/quickandnimble 

## Test Steps
* Run through the tests and confirm that it succeeds repeatedly 

## PR Checklist:
- [x] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N / A Self Accessibility Review
- [x] Basic Self QA

## Screenshots
