### PR TITLE
feat(package): add missing analytics dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
         .target(
             name: "MoSoAnalytics",
             dependencies: [
+                "MoSoCore",
                 .product(name: "Glean", package: "glean-swift")
             ]
         ),


### PR DESCRIPTION
## Summary

Adds missing `MoSoCore` dependency to Analytics target

## Implementation Details

The Analytics package was importing `MoSoCore`, which was not added as a dependency. When building the project on a fresh clone, the build would error out.

## Test Steps

- [ ] Clone the repo, checking out this branch
- [ ] Build
- [ ] The build should not error out

## PR Checklist:
- [ ] Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- [ ] Self Accessibility Review
- [x] Basic Self QA
