### PR TITLE
feat(discover): fix background color for webview + spacing

### DIFF
--- a/Sources/DesignKit/Colors/ColorCatalog.swift
+++ b/Sources/DesignKit/Colors/ColorCatalog.swift
@@ -10,6 +10,16 @@ public extension Color {
     }
 }
 
+public extension UIColor {
+    convenience init?(_ asset: ColorCatalog) {
+        self.init(
+            named: asset.rawValue,
+            in: .module,
+            compatibleWith: nil
+        )
+    }
+}
+
 public enum ColorCatalog: String {
     case mosoLayerColor1 = "moso-layer-color-1"
     case mosoIconColorAccent = "moso-icon-color-accent"

--- a/Sources/DiscoverKit/View/RecommendationDetailView.swift
+++ b/Sources/DiscoverKit/View/RecommendationDetailView.swift
@@ -10,7 +10,9 @@ struct RecommendationDetailView: UIViewRepresentable {
     let recommendation: Recommendation
 
     func makeUIView(context: Context) -> WKWebView {
-        return WKWebView()
+        let webview = WKWebView()
+        webview.backgroundColor = UIColor(.mosoLayerColor1)
+        return webview
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {

--- a/Sources/DiscoverKit/View/RecommendationRow.swift
+++ b/Sources/DiscoverKit/View/RecommendationRow.swift
@@ -50,7 +50,6 @@ struct RecommendationRow: View {
                     .accessibilityLabel(AccessibilityLabels.Discover.recommendationImage)
                     .accessibilityIdentifier(AccessibilityIdentifiers.Discover.recommendationImage)
             }
-            Spacer()
         }
     }
 
@@ -81,7 +80,7 @@ struct RecommendationRow: View {
 
 private extension RecommendationRow {
     enum Constants {
-        static let padding: CGFloat = 16
+        static let padding: CGFloat = 8
         static let spacing: CGFloat = 4
         static let lineLimit: Int = 5
         static let buttonSize: CGFloat = 48


### PR DESCRIPTION
## Summary
Quick fix on background color for web view
Also, adjust spacing and padding per convo with Moiz

## Implementation Details
Update color to using the MoSo background layer color 
Decrease padding between excerpt and buttons by removing `Spacer()`
Decrease padding on items from 16 to 8

## Test Steps
Navigate to discover tab in both dark and light mode
Tap on a recommendation item and verify that the background color matches the MoSo theme

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N / A Self Accessibility Review
- [x] Basic Self QA

## Screenshots
https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/ad3ae980-39a3-40e3-9322-b138f23bc47f


