### PR TITLE
feat: add Keys to fetch secrets from xcconfig file [MOSOIOS-51]

### DIFF
--- a/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
+++ b/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8A735C702AEAB829002F961C /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A735C6F2AEAB829002F961C /* Keys.swift */; };
 		8AA6BA372AC496C800B93B6C /* DesignKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8AA6BA362AC496C800B93B6C /* DesignKit */; };
 		8AE6B2082AC5EAA200F5F1E7 /* UITests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8AE6B2072AC5EAA200F5F1E7 /* UITests.xctestplan */; };
 		AA7BDC602AB2571800ACCACF /* MoSoContentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */; };
@@ -44,6 +45,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8A735C6F2AEAB829002F961C /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
+		8A735C722AEABD49002F961C /* secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets.xcconfig; sourceTree = "<group>"; };
+		8A735C732AEABD49002F961C /* secrets.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text; path = secrets.xcconfig.example; sourceTree = "<group>"; };
 		8AE6B2072AC5EAA200F5F1E7 /* UITests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		AA7BDC5C2AB2571800ACCACF /* MoSoContent.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MoSoContent.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoSoContentApp.swift; sourceTree = "<group>"; };
@@ -93,6 +97,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8A735C712AEABD49002F961C /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				8A735C6F2AEAB829002F961C /* Keys.swift */,
+				8A735C722AEABD49002F961C /* secrets.xcconfig */,
+				8A735C732AEABD49002F961C /* secrets.xcconfig.example */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
 		AA7BDC532AB2571800ACCACF = {
 			isa = PBXGroup;
 			children = (
@@ -119,6 +133,7 @@
 		AA7BDC5E2AB2571800ACCACF /* MoSoContent */ = {
 			isa = PBXGroup;
 			children = (
+				8A735C712AEABD49002F961C /* Config */,
 				AA7BDC992AB2C54200ACCACF /* Info.plist */,
 				AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */,
 				AA7BDC8D2AB25C2200ACCACF /* RootView.swift */,
@@ -338,6 +353,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8D44DD62ACE10220087CE3C /* AuthenticationService.swift in Sources */,
+				8A735C702AEAB829002F961C /* Keys.swift in Sources */,
 				AA7BDC8E2AB25C2200ACCACF /* RootView.swift in Sources */,
 				AA7BDC602AB2571800ACCACF /* MoSoContentApp.swift in Sources */,
 				C8D44DD22ACDC1710087CE3C /* LoginView.swift in Sources */,
@@ -380,6 +396,7 @@
 /* Begin XCBuildConfiguration section */
 		AA7BDC7E2AB2571900ACCACF /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8A735C722AEABD49002F961C /* secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -443,6 +460,7 @@
 		};
 		AA7BDC7F2AB2571900ACCACF /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8A735C722AEABD49002F961C /* secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/Demo/MozillaSocial-iOS/MoSoContent/Config/Keys.swift
+++ b/Demo/MozillaSocial-iOS/MoSoContent/Config/Keys.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+struct Keys {
+    static let shared = Keys()
+
+    let pocketAPIConsumerKey: String
+    let brazeAPIEndpoint: String
+    let brazeAPIKey: String
+    let groupID: String
+
+    private init() {
+        guard let info = Bundle.main.infoDictionary else {
+            fatalError("Unable to load info dictionary for main bundle")
+        }
+
+        guard let pocketAPIConsumerKey = info["PocketAPIConsumerKey"] as? String else {
+            fatalError("Unable to extract PocketAPIConsumerKey from main bundle")
+        }
+
+        guard let brazeAPIEndpoint = info["BrazeAPIEndpoint"] as? String else {
+            fatalError("Unable to extract BrazeAPIEndpoint from main bundle")
+        }
+
+        guard let brazeAPIKey = info["BrazeAPIKey"] as? String else {
+            fatalError("Unable to extract BrazeAPIKey from main bundle")
+        }
+
+        guard let groupID = info["GroupID"] as? String else {
+            fatalError("Unable to extract GroupID from main bundle")
+        }
+
+        self.pocketAPIConsumerKey = pocketAPIConsumerKey
+        self.brazeAPIKey = brazeAPIKey
+        self.brazeAPIEndpoint = brazeAPIEndpoint
+        self.groupID = groupID
+    }
+}

--- a/Demo/MozillaSocial-iOS/MoSoContent/Config/secrets.xcconfig.example
+++ b/Demo/MozillaSocial-iOS/MoSoContent/Config/secrets.xcconfig.example
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+POCKET_API_CONSUMER_KEY=[YOUR-CONSUMER-KEY]
+BRAZE_API_KEY=[YOUR-BRAZE-KEY]
+BRAZE_API_ENDPOINT=[BRAZE-ENDPOINT]
+GROUP_ID=[GROUP_ID]

--- a/Demo/MozillaSocial-iOS/MoSoContent/Info.plist
+++ b/Demo/MozillaSocial-iOS/MoSoContent/Info.plist
@@ -15,7 +15,13 @@
 			</array>
 		</dict>
 	</array>
-	<key>DiscoverApiConsumerKey</key>
-	<string>$(DISCOVER_API_CONSUMER_KEY)</string>
+	<key>PocketAPIConsumerKey</key>
+	<string>$(POCKET_API_CONSUMER_KEY)</string>
+	<key>BrazeAPIEndpoint</key>
+	<string>$(BRAZE_API_ENDPOINT)</string>
+	<key>BrazeAPIKey</key>
+	<string>$(BRAZE_API_KEY)</string>
+	<key>GroupID</key>
+	<string>$(GROUP_ID)</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -158,3 +158,12 @@ struct MyView: View {
 ## Contributing
 At this moment, only members of the Mozilla Social organization can contribute to this repo, open contribution will be available soon.
 
+## Setup Secrets File
+
+The MozillaSocial-iOS demo app requires a secrets.xcconfig file to run. If you are a Mozillan, you can obtain the actual secret keys from the team. Once obtained the keys, you can run the following command from the root directory:
+
+```
+cp Demo/MozillaSocial-iOS/MoSoContent/Config/secrets.xcconfig.example Demo/MozillaSocial-iOS/MoSoContent/Config/secrets.xcconfig
+```
+
+Replace values in `Config/secrets.xcconfig` with the values you have received.


### PR DESCRIPTION
## Summary
Add secrets to our repo

## Implementation Details
* Add `secrets.xcconfig` to Configuration settings for Debug + Release
* Create `Keys` instance to be used for future work (i.e. Braze, Pocket auth)
* Add strings to info.plist
* Update README to include instructions for retrieving secrets

## Test Steps
Please run through the test steps in the README and confirm that instructions are clear.
You can test that proper secret values are being read by putting a breakpoint in the AppConfigurator initializer and print out values for `Keys.shared`.

## PR Checklist:
- N/A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N/A Self Accessibility Review
- [x] Basic Self QA
