### PR TITLE
feat(braze): configure + integrate sdk

### DIFF
--- a/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
+++ b/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		8A735C702AEAB829002F961C /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A735C6F2AEAB829002F961C /* Keys.swift */; };
+		8A735C642AE9AD58002F961C /* BrazeKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8A735C632AE9AD58002F961C /* BrazeKit */; };
+		8A735C672AE9B1B1002F961C /* MoSoBraze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A735C652AE9B1B1002F961C /* MoSoBraze.swift */; };
+		8A735C6A2AE9B1FD002F961C /* BrazeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8A735C692AE9B1FD002F961C /* BrazeUI */; };
 		8AA6BA372AC496C800B93B6C /* DesignKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8AA6BA362AC496C800B93B6C /* DesignKit */; };
 		8AE6B2082AC5EAA200F5F1E7 /* UnitTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 8AE6B2072AC5EAA200F5F1E7 /* UnitTests.xctestplan */; };
 		AA7BDC602AB2571800ACCACF /* MoSoContentApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */; };
@@ -48,6 +51,7 @@
 		8A735C6F2AEAB829002F961C /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
 		8A735C722AEABD49002F961C /* secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = secrets.xcconfig; sourceTree = "<group>"; };
 		8A735C732AEABD49002F961C /* secrets.xcconfig.example */ = {isa = PBXFileReference; lastKnownFileType = text; path = secrets.xcconfig.example; sourceTree = "<group>"; };
+		8A735C652AE9B1B1002F961C /* MoSoBraze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoSoBraze.swift; sourceTree = "<group>"; };
 		8AE6B2072AC5EAA200F5F1E7 /* UITests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UITests.xctestplan; sourceTree = "<group>"; };
 		8AE6B2072AC5EAA200F5F1E7 /* UnitTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		AA528BCF2AEAD5AD004DD8D4 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -76,7 +80,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA7BDC902AB26EFC00ACCACF /* DiscoverKit in Frameworks */,
+				8A735C6A2AE9B1FD002F961C /* BrazeUI in Frameworks */,
 				AA9E65612AD77D2D00BE5789 /* MoSoAnalytics in Frameworks */,
+				8A735C642AE9AD58002F961C /* BrazeKit in Frameworks */,
 				AA7BDC922AB26EFC00ACCACF /* ReadingListKit in Frameworks */,
 				AAE52B662AB2D39900956FBE /* MoSoClient in Frameworks */,
 				AAE52B682AB4CEF400956FBE /* MoSoCore in Frameworks */,
@@ -143,6 +149,8 @@
 				8A735C712AEABD49002F961C /* Config */,
 				AA7BDC992AB2C54200ACCACF /* Info.plist */,
 				AA7BDC5F2AB2571800ACCACF /* MoSoContentApp.swift */,
+				8A735C662AE9B1B1002F961C /* Keys.swift */,
+				8A735C652AE9B1B1002F961C /* MoSoBraze.swift */,
 				AA7BDC8D2AB25C2200ACCACF /* RootView.swift */,
 				AAE52B692AB4CFE300956FBE /* AppConfigurator.swift */,
 				C8D44DD52ACE10220087CE3C /* AuthenticationService.swift */,
@@ -217,6 +225,8 @@
 				AAE52B672AB4CEF400956FBE /* MoSoCore */,
 				8AA6BA362AC496C800B93B6C /* DesignKit */,
 				AA9E65602AD77D2D00BE5789 /* MoSoAnalytics */,
+				8A735C632AE9AD58002F961C /* BrazeKit */,
+				8A735C692AE9B1FD002F961C /* BrazeUI */,
 			);
 			productName = MoSoContent;
 			productReference = AA7BDC5C2AB2571800ACCACF /* MoSoContent.app */;
@@ -293,6 +303,9 @@
 				Base,
 			);
 			mainGroup = AA7BDC532AB2571800ACCACF;
+			packageReferences = (
+				8A735C622AE9AD58002F961C /* XCRemoteSwiftPackageReference "braze-swift-sdk" */,
+			);
 			productRefGroup = AA7BDC5D2AB2571800ACCACF /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -364,6 +377,8 @@
 				AA7BDC8E2AB25C2200ACCACF /* RootView.swift in Sources */,
 				AA7BDC602AB2571800ACCACF /* MoSoContentApp.swift in Sources */,
 				C8D44DD22ACDC1710087CE3C /* LoginView.swift in Sources */,
+				8A735C682AE9B1B1002F961C /* Keys.swift in Sources */,
+				8A735C672AE9B1B1002F961C /* MoSoBraze.swift in Sources */,
 				AAE52B6A2AB4CFE300956FBE /* AppConfigurator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -703,7 +718,28 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		8A735C622AE9AD58002F961C /* XCRemoteSwiftPackageReference "braze-swift-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/braze-inc/braze-swift-sdk";
+			requirement = {
+				kind = exactVersion;
+				version = 7.1.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		8A735C632AE9AD58002F961C /* BrazeKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8A735C622AE9AD58002F961C /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazeKit;
+		};
+		8A735C692AE9B1FD002F961C /* BrazeUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8A735C622AE9AD58002F961C /* XCRemoteSwiftPackageReference "braze-swift-sdk" */;
+			productName = BrazeUI;
+		};
 		8AA6BA362AC496C800B93B6C /* DesignKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DesignKit;

--- a/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/MozillaSocial-iOS/MoSoContent.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "braze-swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/braze-inc/braze-swift-sdk",
+      "state" : {
+        "revision" : "d2b2407bb184e1eded6209458be94e7761ed4b91",
+        "version" : "7.1.0"
+      }
+    },
+    {
       "identity" : "glean-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
         "revision" : "63e6475bd275399b701951925c64fd4c9a5f7c2d",
         "version" : "54.0.0"
+      }
+    },
+    {
+      "identity" : "sdwebimage",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "state" : {
+        "revision" : "1f06ef5007b6a580b3873ed2adee19e05d3b215a",
+        "version" : "5.18.3"
       }
     }
   ],

--- a/Demo/MozillaSocial-iOS/MoSoContent/AppConfigurator.swift
+++ b/Demo/MozillaSocial-iOS/MoSoContent/AppConfigurator.swift
@@ -12,11 +12,7 @@ struct AppConfigurator {
     let session: MoSoSession
     let analyticsProvider: AnalyticsProvider
     let discoverProvider: DiscoverProvider
-    let braze = MoSoBraze(
-        apiKey: Keys.shared.brazeAPIKey,
-        endpoint: Keys.shared.brazeAPIEndpoint,
-        groupId: Keys.shared.groupID
-    )
+    let braze: MoSoBraze
 
     var loggedIn: Bool {
         session.isLoggedIn
@@ -26,12 +22,18 @@ struct AppConfigurator {
         session = MoSoSession()
         analyticsProvider = AnalyticsProvider(session: session)
         discoverProvider  = DiscoverProvider(session: session, tracker: analyticsProvider.makeDiscoverTracker())
+        braze = MoSoBraze(
+            apiKey: Keys.shared.brazeAPIKey,
+            endpoint: Keys.shared.brazeAPIEndpoint,
+            groupId: Keys.shared.groupID
+        )
         // TODO: replace this with actual user coming from login
         login(user: MoSoUser(username: "test-user@mozilla.com", identifier: "12345678"))
     }
 
     func login(user: MoSoUser) {
         session.loggedIn(user)
+        braze.changeUser(userId: user.identifier, email: user.username)
     }
 
     func logout() {

--- a/Demo/MozillaSocial-iOS/MoSoContent/AppConfigurator.swift
+++ b/Demo/MozillaSocial-iOS/MoSoContent/AppConfigurator.swift
@@ -12,6 +12,11 @@ struct AppConfigurator {
     let session: MoSoSession
     let analyticsProvider: AnalyticsProvider
     let discoverProvider: DiscoverProvider
+    let braze = MoSoBraze(
+        apiKey: Keys.shared.brazeAPIKey,
+        endpoint: Keys.shared.brazeAPIEndpoint,
+        groupId: Keys.shared.groupID
+    )
 
     var loggedIn: Bool {
         session.isLoggedIn

--- a/Demo/MozillaSocial-iOS/MoSoContent/MoSoBraze.swift
+++ b/Demo/MozillaSocial-iOS/MoSoContent/MoSoBraze.swift
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import BrazeKit
+import Foundation
+import BrazeUI
+
+/**
+ Class that is managing our Braze SDK implementation
+ */
+public class MoSoBraze: NSObject, BrazeInAppMessageUIDelegate {
+    /// Our Braze SDK Object
+    var braze: Braze
+
+    init(apiKey: String, endpoint: String, groupId: String) {
+        let configuration = Braze.Configuration(
+            apiKey: apiKey,
+            endpoint: endpoint
+        )
+
+        // Enable logging of general SDK information (e.g. user changes, etc.)
+        configuration.logger.level = .info
+        configuration.push.appGroup = groupId
+
+        braze = Braze(configuration: configuration)
+
+        super.init()
+
+        setupInAppMessaging()
+    }
+
+    private func setupInAppMessaging() {
+        let inAppMessageUI = BrazeInAppMessageUI()
+        inAppMessageUI.delegate = self
+        braze.inAppMessagePresenter = inAppMessageUI
+    }
+}

--- a/Demo/MozillaSocial-iOS/MoSoContent/MoSoBraze.swift
+++ b/Demo/MozillaSocial-iOS/MoSoContent/MoSoBraze.swift
@@ -35,4 +35,10 @@ public class MoSoBraze: NSObject, BrazeInAppMessageUIDelegate {
         inAppMessageUI.delegate = self
         braze.inAppMessagePresenter = inAppMessageUI
     }
+
+    func changeUser(userId: String, email: String) {
+        braze.changeUser(userId: userId)
+        let brazeUser = braze.user
+        brazeUser.set(email: email)
+    }
 }


### PR DESCRIPTION
## Summary
Integrate and configure Braze SDK 

[Braze official documentation](https://www.braze.com/docs/developer_guide/platform_integration_guides/ios/initial_sdk_setup/installation_methods/swift_package_manager/)

## Implementation Details
* Add the Braze SDK as a dependency via SPM (BrazeKit, UI)
* Add the correct API key as a secret to secrets.xcconfig (see vault), and updated CI accordingly.
* Initialize the Braze SDK appropriately
* Added ability to send basic in app messaging (see screenshot)
* Setting user ID per [docs](https://www.braze.com/docs/developer_guide/platform_integration_guides/swift/analytics/setting_user_ids/)

## Test Steps
Login to Braze and test the in app messaging functionality by starting "Cyndi's Test Campaign" [here](https://dashboard-05.braze.com/engagement/campaigns/653abe227c22d9004b2b3006/61bce972ee82a901cee0cf63?page=-2&campaignName=Cyndi%27s%20Test%20Campaign&locale=en).
After starting the campaign, relaunch the app and you should receive a message.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N / A Self Accessibility Review
- [x] Basic Self QA

## Screenshots
**Testing for In app messaging**
<img src="https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/5c89d580-bc77-4f76-8ec3-ab43ecfe741e" width="200"> 
