### PR TITLE
fix(discover): add mixed localization property key to info.plist

### DIFF
--- a/Demo/MozillaSocial-iOS/MoSoContent/Info.plist
+++ b/Demo/MozillaSocial-iOS/MoSoContent/Info.plist
@@ -23,6 +23,8 @@
 	<string>$(BRAZE_API_KEY)</string>
 	<key>GroupID</key>
 	<string>$(GROUP_ID)</string>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 	<key>DiscoverApiConsumerKey</key>
 	<string>$(DISCOVER_API_CONSUMER_KEY)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
## Summary
Fix issue where german recommendations are not appearing properly.

Documentation: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleallowmixedlocalizations

## Implementation Details
* Add  `CFBundleAllowMixedLocalizations` in `Info.plist`. Set this value to true

Under iOS 11, Locale only returns languages supported by our app's localizations. If seems we only supported English, so current Locale will always return English. This key will cause Locale.current to always use the locale specified in user preferences.

## Test Steps
Run this branch and switch the language + region to German. Verify that you can now view German recommendations.

## PR Checklist:
- N / A Added Unit / UI tests
- [x] Self Review (review, clean up, documentation, run tests)
- N / A Self Accessibility Review
- [x] Basic Self QA

## Screenshots
<img src="https://github.com/MozillaSocial/mozilla-social-ios/assets/6743397/2e3ed511-b4ce-4162-83d3-fc6b10128fc9" width="200" />