### PR TITLE
ReadingList Items navigate to a webview like DiscoverKit items

### DIFF
--- a/Sources/DesignKit/Views/WebView.swift
+++ b/Sources/DesignKit/Views/WebView.swift
@@ -6,18 +6,22 @@ import SwiftUI
 import WebKit
 
 // TODO: at this moment, this just loads an url in a web view. We will add a proper recommendation view after beta
-struct RecommendationDetailView: UIViewRepresentable {
-    let recommendation: Recommendation
+public struct WebView: UIViewRepresentable {
+    public let url: String
 
-    func makeUIView(context: Context) -> WKWebView {
+    public init(url: String) {
+        self.url = url
+    }
+
+    public func makeUIView(context: Context) -> WKWebView {
         let webview = WKWebView()
         webview.backgroundColor = UIColor(.mosoLayerColor1)
         return webview
     }
 
-    func updateUIView(_ webView: WKWebView, context: Context) {
+    public func updateUIView(_ webView: WKWebView, context: Context) {
         // TODO: this is just an example fallback, we need to add a proper error view
-        let url = URL(string: recommendation.url) ?? URL(string: "https.getpocket.com")!
+        let url = URL(string: url) ?? URL(string: "https.getpocket.com")!
         let request = URLRequest(url: url)
         webView.load(request)
     }

--- a/Sources/DiscoverKit/View/RecommendationsView.swift
+++ b/Sources/DiscoverKit/View/RecommendationsView.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import SwiftUI
+import DesignKit
 
 struct RecommendationsView: View {
     let recommendations: [Recommendation]
@@ -25,7 +26,7 @@ struct RecommendationsView: View {
                 Color(.mosoLayerColor1).ignoresSafeArea()
                     ListView(recommendations: recommendations)
                         .navigationDestination(for: Recommendation.self) { recommendation in
-                            RecommendationDetailView(recommendation: recommendation)
+                            WebView(url: recommendation.url)
                                 .navigationBarTitleDisplayMode(.inline)
                                 .toolbarBackground(.visible, for: .navigationBar)
                                 .toolbarBackground(Color(.mosoLayerColor1), for: .navigationBar)

--- a/Sources/ReadingListKit/ReadingListCell.swift
+++ b/Sources/ReadingListKit/ReadingListCell.swift
@@ -8,7 +8,6 @@ import DesignKit
 
 public struct ReadingListCell: View {
     let model: ReadingListCellViewModel
-    @Binding var selectedRow: ReadingListCellViewModel?
     let archiveAction: (String) -> Void
     let shareAction: (String) -> Void
 
@@ -68,9 +67,6 @@ public struct ReadingListCell: View {
         }
         .padding()
         .contentShape(Rectangle())
-        .onTapGesture {
-            selectedRow = model
-        }
     }
 
     // MARK: - Constants

--- a/Sources/ReadingListKit/ReadingListCellViewModel.swift
+++ b/Sources/ReadingListKit/ReadingListCellViewModel.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-struct ReadingListCellViewModel: Observable, Identifiable, Equatable {
+struct ReadingListCellViewModel: Observable, Identifiable, Equatable, Hashable {
     var id: String
     let title: String
     let subtitle: String

--- a/Sources/ReadingListKit/ReadingListView.swift
+++ b/Sources/ReadingListKit/ReadingListView.swift
@@ -4,15 +4,13 @@
 
 import SwiftUI
 import Combine
+import DesignKit
 
 public struct ReadingListView: View {
     @StateObject var model: ReadingListModel
-    @State private var selectedRow: ReadingListCellViewModel?
 
     @Environment(\.horizontalSizeClass)
     var sizeClass
-    @Environment(\.openURL)
-    var openURL
 
     func archiveAction(item: String) {
         model.archive(item: item)
@@ -28,15 +26,6 @@ public struct ReadingListView: View {
             ScrollView {
                 ReadingListContentView
                 .navigationTitle(Text("Reading List"))
-            }
-            .onChange(of: selectedRow) { newValue in
-                guard let urlString = newValue?.contentURL,
-                      let url = URL(string: urlString) else {
-                    return
-                }
-                selectedRow = nil
-                openURL(url)
-                model.trackReadingListItemOpen(itemURL: urlString)
             }
             .onAppear {
                 model.trackReadingListViewImpression()
@@ -55,17 +44,20 @@ public struct ReadingListView: View {
         LazyVStack {
             ForEach(model.readingListItems, id: \.id) { viewModel in
                 VStack {
-                    ReadingListCell(model: viewModel, selectedRow: $selectedRow, archiveAction: self.archiveAction, shareAction: self.shareAction)
-                        .navigationBarTitleDisplayMode(.inline)
-                        .toolbarBackground(.visible, for: .navigationBar)
-                        .toolbarBackground(Color(.mosoLayerColor1), for: .navigationBar)
-                        .onAppear {
-                            model.didDisplayItem(with: viewModel.id)
-                            model.trackReadingListItemImpression(itemURL: viewModel.contentURL)
-                        }
-                        .if(sizeClass == .regular) { view in
-                            view.frame(width: Constants.readableWidth, alignment: .center)
-                        }
+                    NavigationLink(value: viewModel) {
+                        ReadingListCell(model: viewModel, archiveAction: self.archiveAction, shareAction: self.shareAction)
+                            .navigationBarTitleDisplayMode(.inline)
+                            .toolbarBackground(.visible, for: .navigationBar)
+                            .toolbarBackground(Color(.mosoLayerColor1), for: .navigationBar)
+                            .onAppear {
+                                model.didDisplayItem(with: viewModel.id)
+                                model.trackReadingListItemImpression(itemURL: viewModel.contentURL)
+                            }
+                            .if(sizeClass == .regular) { view in
+                                view.frame(width: Constants.readableWidth, alignment: .center)
+                            }
+                    }
+                    .buttonStyle(.plain)
 
                     Divider()
                 }
@@ -74,6 +66,15 @@ public struct ReadingListView: View {
             if model.allItemsAreDownloaded() == false && model.displayMode == .normal {
                 ProgressView()
             }
+        }
+        .navigationDestination(for: ReadingListCellViewModel.self) { viewModel in
+            WebView(url: viewModel.contentURL)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.visible, for: .navigationBar)
+                .toolbarBackground(Color(.mosoLayerColor1), for: .navigationBar)
+                .onAppear {
+                    model.trackReadingListItemOpen(itemURL: viewModel.contentURL)
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
As title

## Implementation Details
Abstracted and generalized the RecommendationDetailView out of DiscoverKit to DesignKit.
Added NavigationLinks to ReadingList items.
Removed a bunch of code related to the old way of handling item selection.

## Screenshots
![Simulator Screen Recording - iPad (10th generation) - 2023-12-12 at 12 14 53](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/156bb8e4-8713-4b2a-ba86-790df6c573dd)
