### PR TITLE
Fix odd layout on phones

### DIFF
--- a/Sources/ReadingListKit/ReadingListView.swift
+++ b/Sources/ReadingListKit/ReadingListView.swift
@@ -58,10 +58,8 @@ public struct ReadingListView: View {
                             }
                     }
                     .buttonStyle(.plain)
-
                     Divider()
                 }
-                .fixedSize(horizontal: true, vertical: false)
             }
             if model.allItemsAreDownloaded() == false && model.displayMode == .normal {
                 ProgressView()


### PR DESCRIPTION
## Summary
Layout widths were arbitrary on .compact devices.

## Screenshots
Before:
![image](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/34739381-d161-4315-b569-5840f92105bf)

Fixed:
![image](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/9cc93611-6277-4325-8ed1-31a9ef2ac4fe)

