### PR TITLE
Add new Toast view

### DIFF
--- a/Sources/DesignKit/View+Extensions.swift
+++ b/Sources/DesignKit/View+Extensions.swift
@@ -13,4 +13,8 @@ extension View {
             self
         }
     }
+
+    func toastView(config: Binding<ToastConfiguration?>) -> some View {
+        self.modifier(ToastModifier(configuration: config))
+      }
 }

--- a/Sources/DesignKit/Views/Toast/Toast.swift
+++ b/Sources/DesignKit/Views/Toast/Toast.swift
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct Toast: View {
+    let cornerRadius: CGFloat = 8
+
+    var style: ToastStyle
+    var message: String
+    var width = CGFloat.infinity
+    var onCancelTapped: (() -> Void)
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: style.iconFileName)
+                .foregroundColor(style.themeColor)
+            Text(message)
+                .font(Font.caption)
+
+            Spacer(minLength: 10)
+
+            Button {
+                onCancelTapped()
+            } label: {
+                Image(systemName: "xmark")
+                    .foregroundColor(style.themeColor)
+            }
+        }
+        .padding()
+        .frame(minWidth: 0, maxWidth: width)
+        .background(Color(uiColor: .secondarySystemBackground))
+        .cornerRadius(cornerRadius)
+        .overlay {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(lineWidth: 1)
+                .foregroundStyle(style.themeColor)
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+#Preview {
+    List(ToastStyle.allCases, id: \.hashValue) { style in
+        Toast(style: style, message: style.iconFileName, onCancelTapped: {})
+    }
+}

--- a/Sources/DesignKit/Views/Toast/ToastConfiguration.swift
+++ b/Sources/DesignKit/Views/Toast/ToastConfiguration.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+struct ToastConfiguration: Equatable {
+  var style: ToastStyle
+  var message: String
+  var duration: Double = 3
+  var width: Double = .infinity
+}

--- a/Sources/DesignKit/Views/Toast/ToastModifier.swift
+++ b/Sources/DesignKit/Views/Toast/ToastModifier.swift
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct ToastModifier: ViewModifier {
+  @Binding var configuration: ToastConfiguration?
+  @State private var workItem: DispatchWorkItem?
+
+  func body(content: Content) -> some View {
+    content
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .overlay(
+        ZStack {
+          mainToastView()
+            .offset(y: 32)
+        }.animation(.spring(), value: configuration)
+      )
+      .onChange(of: configuration) { value in
+        showToast()
+      }
+  }
+
+    @ViewBuilder
+    func mainToastView() -> some View {
+    if let config = configuration {
+      VStack {
+        Toast(
+          style: config.style,
+          message: config.message,
+          width: config.width
+        ) {
+          dismissToast()
+        }
+        Spacer()
+      }
+    }
+  }
+
+  private func showToast() {
+    guard let toast = configuration else { return }
+
+    UIImpactFeedbackGenerator(style: .light)
+      .impactOccurred()
+
+    if toast.duration > 0 {
+      workItem?.cancel()
+
+      let task = DispatchWorkItem {
+        dismissToast()
+      }
+
+      workItem = task
+      DispatchQueue.main.asyncAfter(deadline: .now() + toast.duration, execute: task)
+    }
+  }
+
+  private func dismissToast() {
+    withAnimation {
+      configuration = nil
+    }
+
+    workItem?.cancel()
+    workItem = nil
+  }
+}

--- a/Sources/DesignKit/Views/Toast/ToastStyle.swift
+++ b/Sources/DesignKit/Views/Toast/ToastStyle.swift
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+enum ToastStyle: CaseIterable {
+  case error
+  case warning
+  case success
+  case info
+
+  var themeColor: Color {
+    switch self {
+    case .error: return Color.red
+    case .warning: return Color.orange
+    case .info: return Color.blue
+    case .success: return Color.green
+    }
+  }
+
+  var iconFileName: String {
+    switch self {
+    case .info: return "info.circle.fill"
+    case .warning: return "exclamationmark.triangle.fill"
+    case .success: return "checkmark.circle.fill"
+    case .error: return "xmark.circle.fill"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a Toast-style overlay view.
Useful for notifying users that something has happened.
Includes haptics.

## Screenshots

<img width="459" alt="image" src="https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/a4297f90-4a9e-48b4-9de6-e59a500f1a26">

<img width="457" alt="image" src="https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/60d96504-fa8e-4e7f-95fc-7631a590286d">
