### PR TITLE
Make Toast public. Fire from ReadingListModel

### DIFF
--- a/Sources/DesignKit/View+Extensions.swift
+++ b/Sources/DesignKit/View+Extensions.swift
@@ -14,7 +14,7 @@ extension View {
         }
     }
 
-    func toastView(config: Binding<ToastConfiguration?>) -> some View {
+    public func toastView(config: Binding<ToastConfiguration?>) -> some View {
         self.modifier(ToastModifier(configuration: config))
       }
 }

--- a/Sources/DesignKit/Views/Toast/Toast.swift
+++ b/Sources/DesignKit/Views/Toast/Toast.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-struct Toast: View {
+public struct Toast: View {
     let cornerRadius: CGFloat = 8
 
     var style: ToastStyle
@@ -12,7 +12,7 @@ struct Toast: View {
     var width = CGFloat.infinity
     var onCancelTapped: (() -> Void)
 
-    var body: some View {
+    public var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Image(systemName: style.iconFileName)
                 .foregroundColor(style.themeColor)

--- a/Sources/DesignKit/Views/Toast/ToastConfiguration.swift
+++ b/Sources/DesignKit/Views/Toast/ToastConfiguration.swift
@@ -4,9 +4,16 @@
 
 import Foundation
 
-struct ToastConfiguration: Equatable {
-  var style: ToastStyle
-  var message: String
-  var duration: Double = 3
-  var width: Double = .infinity
+public struct ToastConfiguration: Equatable {
+    var style: ToastStyle
+    var message: String
+    var duration: Double
+    var width: Double
+
+    public init(style: ToastStyle, message: String, duration: Double = 3, width: Double = .infinity) {
+        self.style = style
+        self.message = message
+        self.duration = duration
+        self.width = width
+    }
 }

--- a/Sources/DesignKit/Views/Toast/ToastModifier.swift
+++ b/Sources/DesignKit/Views/Toast/ToastModifier.swift
@@ -4,64 +4,64 @@
 
 import SwiftUI
 
-struct ToastModifier: ViewModifier {
-  @Binding var configuration: ToastConfiguration?
-  @State private var workItem: DispatchWorkItem?
+public struct ToastModifier: ViewModifier {
+    @Binding var configuration: ToastConfiguration?
+    @State private var workItem: DispatchWorkItem?
 
-  func body(content: Content) -> some View {
-    content
-      .frame(maxWidth: .infinity, maxHeight: .infinity)
-      .overlay(
-        ZStack {
-          mainToastView()
-            .offset(y: 32)
-        }.animation(.spring(), value: configuration)
-      )
-      .onChange(of: configuration) { value in
-        showToast()
-      }
-  }
+    public func body(content: Content) -> some View {
+        content
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(
+                ZStack {
+                    mainToastView()
+                        .offset(y: 32)
+                }.animation(.spring(), value: configuration)
+            )
+            .onChange(of: configuration) { value in
+                showToast()
+            }
+    }
 
     @ViewBuilder
-    func mainToastView() -> some View {
-    if let config = configuration {
-      VStack {
-        Toast(
-          style: config.style,
-          message: config.message,
-          width: config.width
-        ) {
-          dismissToast()
+    public func mainToastView() -> some View {
+        if let config = configuration {
+            VStack {
+                Toast(
+                    style: config.style,
+                    message: config.message,
+                    width: config.width
+                ) {
+                    dismissToast()
+                }
+                Spacer()
+            }
         }
-        Spacer()
-      }
-    }
-  }
-
-  private func showToast() {
-    guard let toast = configuration else { return }
-
-    UIImpactFeedbackGenerator(style: .light)
-      .impactOccurred()
-
-    if toast.duration > 0 {
-      workItem?.cancel()
-
-      let task = DispatchWorkItem {
-        dismissToast()
-      }
-
-      workItem = task
-      DispatchQueue.main.asyncAfter(deadline: .now() + toast.duration, execute: task)
-    }
-  }
-
-  private func dismissToast() {
-    withAnimation {
-      configuration = nil
     }
 
-    workItem?.cancel()
-    workItem = nil
-  }
+    private func showToast() {
+        guard let toast = configuration else { return }
+
+        UIImpactFeedbackGenerator(style: .light)
+            .impactOccurred()
+
+        if toast.duration > 0 {
+            workItem?.cancel()
+
+            let task = DispatchWorkItem {
+                dismissToast()
+            }
+
+            workItem = task
+            DispatchQueue.main.asyncAfter(deadline: .now() + toast.duration, execute: task)
+        }
+    }
+
+    private func dismissToast() {
+        withAnimation {
+            configuration = nil
+        }
+
+        workItem?.cancel()
+        workItem = nil
+    }
 }

--- a/Sources/DesignKit/Views/Toast/ToastStyle.swift
+++ b/Sources/DesignKit/Views/Toast/ToastStyle.swift
@@ -4,27 +4,27 @@
 
 import SwiftUI
 
-enum ToastStyle: CaseIterable {
-  case error
-  case warning
-  case success
-  case info
+public enum ToastStyle: CaseIterable {
+    case error
+    case warning
+    case success
+    case info
 
-  var themeColor: Color {
-    switch self {
-    case .error: return Color.red
-    case .warning: return Color.orange
-    case .info: return Color.blue
-    case .success: return Color.green
+    var themeColor: Color {
+        switch self {
+        case .error: return Color.red
+        case .warning: return Color.orange
+        case .info: return Color.blue
+        case .success: return Color.green
+        }
     }
-  }
 
-  var iconFileName: String {
-    switch self {
-    case .info: return "info.circle.fill"
-    case .warning: return "exclamationmark.triangle.fill"
-    case .success: return "checkmark.circle.fill"
-    case .error: return "xmark.circle.fill"
+    var iconFileName: String {
+        switch self {
+        case .info: return "info.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .success: return "checkmark.circle.fill"
+        case .error: return "xmark.circle.fill"
+        }
     }
-  }
 }

--- a/Sources/ReadingListKit/PocketAccessLayer.swift
+++ b/Sources/ReadingListKit/PocketAccessLayer.swift
@@ -26,6 +26,7 @@ public typealias ReadingListSessionProvider = () throws -> ReadingListSession
 enum PocketAccessLayerError: Error {
     case failedToFetchList(_ reason: String)
     case failedToFetchItem(_ itemURLString: String)
+    case failedToArchiveItem(_ itemURLString: String)
     case invalidAuthentication
 }
 
@@ -134,9 +135,14 @@ class PocketAccessLayer: PocketAccessLayerProtocol {
         apolloClient?.perform(mutation: mutation) { [weak self] result in
             switch result {
             case .success(let data):
+                guard data.errors?.first == nil else {
+                    self?.delegate?.operationFailed(with: .failedToArchiveItem(item))
+                    return
+                }
+
                 self?.delegate?.removeItemFromList(item: item)
             case .failure(let error):
-                print(error)
+                self?.delegate?.operationFailed(with: .failedToArchiveItem(item))
             }
         }
     }

--- a/Sources/ReadingListKit/ReadingListModel.swift
+++ b/Sources/ReadingListKit/ReadingListModel.swift
@@ -6,6 +6,7 @@ import Foundation
 import Combine
 import MoSoAnalytics
 import MoSoCore
+import DesignKit
 
 protocol ReadingListModelDelegate: AnyObject {
     func didFetchReadingListItems(urlStrings: [String], totalItemCount: Int, cursor: String?)
@@ -29,6 +30,7 @@ public class ReadingListModel: ReadingListModelDelegate, ObservableObject {
     var totalNumberOfItemsInReadingList: Int?
     @Published private(set) var displayMode: ReadingListDisplayMode = .normal
     @Published private(set) var readingListItems: [ReadingListCellViewModel] = []
+    @Published var toast: ToastConfiguration?
     private var paginationCursor: String?
 
     public init(sessionProvider: @escaping ReadingListSessionProvider, consumerKey: String, analyticsTracker: ReadingListTracker) {
@@ -119,6 +121,8 @@ public class ReadingListModel: ReadingListModelDelegate, ObservableObject {
     func operationFailed(with error: PocketAccessLayerError) {
         if case PocketAccessLayerError.invalidAuthentication = error {
             displayMode = .loggedOut
+        } else if case PocketAccessLayerError.failedToArchiveItem = error {
+            toast = ToastConfiguration(style: .error, message: "Unable to Archive item")
         } else {
             displayMode = .error
         }

--- a/Sources/ReadingListKit/ReadingListView.swift
+++ b/Sources/ReadingListKit/ReadingListView.swift
@@ -37,6 +37,7 @@ public struct ReadingListView: View {
                     Text("Your Reading List is empty!")
                 }
             }
+            .toastView(config: $model.toast)
         }
     }
 


### PR DESCRIPTION
## Summary
When a user tries to Archive an item and receives and error, the Toast should display notifying them that something went wrong.

## Implementation Details
Currently the ReadingListModel decides how to fire the Toast, which I don't like. I'd prefer the View does that work. But maybe this is more SwiftUI?

## Test Steps
PM me for a login that has 2 items that currently cannot be Archived.
On the Readinglist view attempt to archive and the Toast should appear for 3 seconds or until dismissed, whichever is sooner.

## Screenshots
![Simulator Screen Recording - iPad Air (5th generation) - 2024-01-08 at 17 39 05](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/f72231c5-fcc2-4b99-ad7f-7b333f822b4c)
![Simulator Screen Recording - iPhone 15 Pro - 2024-01-08 at 17 19 56](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/30436073-d968-4b65-a248-3328675cbe17)
![Simulator Screen Recording - iPhone 15 Pro - 2024-01-08 at 17 19 17](https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/a3ea5afc-5709-43d3-b18c-9ac5a4998eab)
