### PR TITLE
Add a Segmented Control matching the Figma designs

### DIFF
--- a/Sources/DesignKit/Views/SegmentedControl.swift
+++ b/Sources/DesignKit/Views/SegmentedControl.swift
@@ -17,8 +17,7 @@ struct SegmentedControl: View {
                 } label: {
                     VStack {
                         Text(segment)
-                            .font(.footnote)
-                            .fontWeight(.medium)
+                            .fontWeight(.heavy)
                             .foregroundStyle(selected == segment ? Color.accentColor : .secondary)
                         ZStack {
                             Rectangle()

--- a/Sources/DesignKit/Views/SegmentedControl.swift
+++ b/Sources/DesignKit/Views/SegmentedControl.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import SwiftUI
+
+struct SegmentedControl: View {
+    public let sources: [String]
+    @Binding public var selected: String
+    @Namespace var namespace
+
+    var body: some View {
+        HStack {
+            ForEach(sources, id: \.self) { segment in
+                Button {
+                    selected = segment
+                } label: {
+                    VStack {
+                        Text(segment)
+                            .font(.footnote)
+                            .fontWeight(.medium)
+                            .foregroundStyle(selected == segment ? Color.accentColor : .secondary)
+                        ZStack {
+                            Rectangle()
+                                .fill(.clear)
+                                .frame(height: 4)
+                            if selected == segment {
+                                Rectangle()
+                                    .fill(Color.accentColor)
+                                    .frame(height: 4)
+                                    .matchedGeometryEffect(id: "Segment", in: namespace)
+                            }
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+private struct SegmentedControlPreviewWrapper: View {
+    @State var selected = "One"
+    var body: some View {
+        SegmentedControl(sources: ["One", "Two", "Three"], selected: $selected)
+            .accentColor(.green)
+    }
+}
+
+#Preview {
+    SegmentedControlPreviewWrapper()
+}


### PR DESCRIPTION
## Summary
Add a Segmented Control component that matches the Figma designs.
Changing the selection is animated by the .matchedGeometryEffect modifier.
Color is set by the AccentColor (Deprecated), setting the Tint had no affect.

## Screenshots
<img width="260" alt="Screenshot 2024-01-16 at 1 54 28 PM" src="https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/dade236b-5ecd-434a-9f82-b837f301dce4">
<img width="257" alt="Screenshot 2024-01-16 at 1 54 21 PM" src="https://github.com/MozillaSocial/mozilla-social-ios/assets/8590135/42a6c15d-1ae2-4031-895a-5ab089696f14">

